### PR TITLE
Remote Programming Makefile Updates

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -38,6 +38,8 @@ WINDOWS := false
 MAC_OS := false
 LINUX := false
 
+REMOTE := false
+
 ifeq ($(OS),Windows_NT)
 	WINDOWS := true
 else
@@ -63,15 +65,12 @@ ifeq ($(MAC_OS), true)
 endif
 ifeq ($(LINUX), true)
 	# lower number
-	PORT = $(shell find /dev -name 'ttyS[0-9]*' | sort | head -n1)
+	PORT = $(shell pavr2cmd --prog-port)
+	UART = $(shell pavr2cmd --ttl-port)
+	ifeq ($(shell whoami),ss)
+		REMOTE := true
+	endif
 endif
-
-# If automatic port detection fails,
-# uncomment one of these lines and change it to set the port manually
-PORT = COM6						# Windows
-# PORT = /dev/tty.usbmodem00208212	# macOS
-# PORT = /dev/ttyS3					# Linux
-
 
 # Special commands
 .PHONY: all clean debug help lib-common read-eeprom upload
@@ -147,4 +146,18 @@ endif
 
 # Upload .hex program to device
 upload: $(PROG)
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 IN
+	gpio -g mode 15 IN
+endif
 	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$^.hex
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 ALT0
+	gpio -g mode 15 ALT0
+endif
+
+# Upload .hex program to device, using a precompiled binary that must already be
+# in the folder and be named $(PROG).hex
+# (does not compile anything, just uploads the hex file)
+upload_bin:
+	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$(PROG).hex

--- a/harness_tests/makefile
+++ b/harness_tests/makefile
@@ -12,9 +12,9 @@ LIB_COMMON = ../../lib-common
 INCLUDES = -I$(LIB_COMMON)/include
 # Libraries from lib-common to link
 # For some reason, conversions needs to come after dac or else it gives an error
-# Need to put dac before conversions, uptime before timer,
+# Need to put dac before conversions, uptime before timer, heartbeat before can,
 # or else gives an error for undefined reference
-LIB = -L$(LIB_COMMON)/lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -luptime -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
+LIB = -L$(LIB_COMMON)/lib -ladc -lheartbeat -lcan -ldac -lconversions -lpex -lqueue -lspi -lstack -ltest -luptime -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
 # Name of microcontroller ("32m1" or "64m1")
 MCU = 32m1
 #-------------------------------------------------------------------------------
@@ -37,6 +37,8 @@ DEVICE = m$(MCU)
 WINDOWS := false
 MAC_OS := false
 LINUX := false
+
+REMOTE := false
 
 ifeq ($(OS),Windows_NT)
 	WINDOWS := true
@@ -63,16 +65,12 @@ ifeq ($(MAC_OS), true)
 endif
 ifeq ($(LINUX), true)
 	# lower number
-	# TODO - test this
-	PORT = $(shell find /dev -name 'ttyS[0-9]*' | sort | head -n1)
+	PORT = $(shell pavr2cmd --prog-port)
+	UART = $(shell pavr2cmd --ttl-port)
+	ifeq ($(shell whoami),ss)
+		REMOTE := true
+	endif
 endif
-
-# If automatic port detection fails,
-# uncomment one of these lines and change it to set the port manually
-# PORT = COM3						# Windows
-# PORT = /dev/tty.usbmodem00208212	# macOS
-# PORT = /dev/ttyS3					# Linux
-
 
 # Special commands
 .PHONY: all clean debug help lib-common read-eeprom upload
@@ -148,4 +146,18 @@ endif
 
 # Upload .hex program to device
 upload: $(PROG)
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 IN
+	gpio -g mode 15 IN
+endif
 	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$^.hex
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 ALT0
+	gpio -g mode 15 ALT0
+endif
+
+# Upload .hex program to device, using a precompiled binary that must already be
+# in the folder and be named $(PROG).hex
+# (does not compile anything, just uploads the hex file)
+upload_bin:
+	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$(PROG).hex

--- a/makefile
+++ b/makefile
@@ -78,13 +78,6 @@ ifeq ($(LINUX), true)
 	endif
 endif
 
-# If automatic port detection fails,
-# uncomment one of these lines and change it to set the port manually
-# PORT = COM3						# Windows
-# PORT = /dev/tty.usbmodem00208212	# macOS
-# PORT = /dev/ttyS3					# Linux
-
-
 # Set the PYTHON variable - Python interpreter
 # Windows uses `python` for either Python 2 or 3,
 # while macOS/Linux use `python3` to explicitly use Python 3
@@ -158,9 +151,10 @@ debug:
 
 # Need to cd into lib-common and refer back up one directory to the harness_tests folder
 # because harness.py has the `include` and `src` paths hardcoded
+# If multi-board testing, PORT2 and UART2 must both be specified
 harness:
 	cd lib-common && \
-	$(PYTHON) ./bin/harness.py -p $(PORT) -u $(UART) -d ../$(TEST) $(HARNESS_ARGS)
+	$(PYTHON) ./bin/harness.py -m $(MCU) -p $(PORT) $(PORT2) -u $(UART) $(UART2) -d ../$(TEST) $(HARNESS_ARGS)
 
 # Help shows available commands
 help:

--- a/makefile
+++ b/makefile
@@ -42,6 +42,8 @@ WINDOWS := false
 MAC_OS := false
 LINUX := false
 
+REMOTE := false
+
 ifeq ($(OS),Windows_NT)
 	WINDOWS := true
 else
@@ -69,8 +71,11 @@ ifeq ($(MAC_OS), true)
 endif
 ifeq ($(LINUX), true)
 	# lower number
-	PORT = $(shell find /dev -name 'ttyS[0-9]*' | sort | head -n1)
-	UART = $(shell find /dev -name 'ttyS[0-9]*' | sort | sed -n 2p)
+	PORT = $(shell pavr2cmd --prog-port)
+	UART = $(shell pavr2cmd --ttl-port)
+	ifeq ($(shell whoami),ss)
+		REMOTE := true
+	endif
 endif
 
 # If automatic port detection fails,
@@ -200,4 +205,12 @@ endif
 
 # Upload program to board
 upload: $(PROG)
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 IN
+	gpio -g mode 15 IN
+endif
 	avrdude -c $(PGMR) -C ./lib-common/avrdude.conf -p $(DEVICE) -P $(PORT) -U flash:w:./build/$^.hex
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 ALT0
+	gpio -g mode 15 ALT0
+endif

--- a/manual_tests/makefile
+++ b/manual_tests/makefile
@@ -38,6 +38,8 @@ WINDOWS := false
 MAC_OS := false
 LINUX := false
 
+REMOTE := false
+
 ifeq ($(OS),Windows_NT)
 	WINDOWS := true
 else
@@ -63,15 +65,12 @@ ifeq ($(MAC_OS), true)
 endif
 ifeq ($(LINUX), true)
 	# lower number
-	PORT = $(shell find /dev -name 'ttyS[0-9]*' | sort | head -n1)
+	PORT = $(shell pavr2cmd --prog-port)
+	UART = $(shell pavr2cmd --ttl-port)
+	ifeq ($(shell whoami),ss)
+		REMOTE := true
+	endif
 endif
-
-# If automatic port detection fails,
-# uncomment one of these lines and change it to set the port manually
-# PORT = COM3						# Windows
-# PORT = /dev/tty.usbmodem00208212	# macOS
-# PORT = /dev/ttyS3					# Linux
-
 
 # Special commands
 .PHONY: all clean debug help lib-common read-eeprom upload
@@ -147,4 +146,18 @@ endif
 
 # Upload .hex program to device
 upload: $(PROG)
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 IN
+	gpio -g mode 15 IN
+endif
 	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$^.hex
+ifeq ($(REMOTE),true)
+	gpio -g mode 14 ALT0
+	gpio -g mode 15 ALT0
+endif
+
+# Upload .hex program to device, using a precompiled binary that must already be
+# in the folder and be named $(PROG).hex
+# (does not compile anything, just uploads the hex file)
+upload_bin:
+	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$(PROG).hex


### PR DESCRIPTION
Adds a new `REMOTE` flag to makefile. `REMOTE` is set if:
- Device is identified as Linux
- Shell call to `whoami` returns `ss`

This requires more generally that all remote programming pi's be registered with the 'ss' username.

If `REMOTE` is set, the `gpio -g mode ...` calls are executed during upload to set the RPI UART lines to INPUT before programming, and to ALT0 (UART) afterwards. This has been tested working with pay-ssm-v3 with UART connected and the board set to PGM.

It also changes the way that `PORT` and `UART` are set on Linux by making a call to `pavr2cmd`, which is more reliable than the old method.